### PR TITLE
fix CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,8 @@ build docs using a pre-commit hook.
 
 - Initial release.
 
-[unreleased]: https://github.com/fpringle/hoyo/compare/v0.1.0.2...HEAD
+[unreleased]: https://github.com/fpringle/hoyo/compare/v0.1.1.0...HEAD
+[0.1.1.0]: https://github.com/fpringle/hoyo/compare/v0.1.0.2...v0.1.1.0
 [0.1.0.2]: https://github.com/fpringle/hoyo/compare/v0.1.0.1...v0.1.0.2
 [0.1.0.1]: https://github.com/fpringle/hoyo/compare/v0.1.0.0...v0.1.0.1
 [0.1.0.0]: https://github.com/fpringle/hoyo/releases/tag/v0.1.0.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -60,7 +60,8 @@ build docs using a pre-commit hook.
 
 - Initial release.
 
-[unreleased]: https://github.com/fpringle/hoyo/compare/v0.1.0.2...HEAD
+[unreleased]: https://github.com/fpringle/hoyo/compare/v0.1.1.0...HEAD
+[0.1.1.0]: https://github.com/fpringle/hoyo/compare/v0.1.0.2...v0.1.1.0
 [0.1.0.2]: https://github.com/fpringle/hoyo/compare/v0.1.0.1...v0.1.0.2
 [0.1.0.1]: https://github.com/fpringle/hoyo/compare/v0.1.0.0...v0.1.0.1
 [0.1.0.0]: https://github.com/fpringle/hoyo/releases/tag/v0.1.0.0


### PR DESCRIPTION
Add link to v0.1.1.0 in CHANGELOG.md.
Can we do this automatically?