### PR TITLE
dev/default command

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -18,6 +18,7 @@ failure err = do
 main :: IO ()
 main = withProgName "hoyo" $ do
   opts@(Options _ globals) <- execParser options
+  print opts
   forM_ (verifyOverrides $ overrides globals) failure
 
   sFp <- maybe defaultConfigPath return $ globalConfigPath globals

--- a/exe/Parse.hs
+++ b/exe/Parse.hs
@@ -67,13 +67,21 @@ bookmarkSearchTerm = eitherReader $ \s ->
   SearchIndex <$> readEither s
   <|> Right (SearchName (T.pack s))
 
+moveCommandMods :: Mod ArgumentFields BookmarkSearchTerm
+moveCommandMods = metavar "<bookmark>"
+                    <> help "Index or name of the bookmark to move to"
+                    <> completer bookmarkCompleter
+
 moveCommand :: Parser Command
 moveCommand = Move . MoveOptions
-                <$> argument bookmarkSearchTerm (
-                      metavar "<bookmark>"
-                      <> help "Index or name of the bookmark to move to"
-                      <> completer bookmarkCompleter
-                    )
+                <$> argument bookmarkSearchTerm moveCommandMods
+
+moveCommandHidden :: Parser Command
+moveCommandHidden = Move . MoveOptions
+                      <$> argument bookmarkSearchTerm (
+                            moveCommandMods
+                            <> internal
+                          )
 
 listCommand :: Parser Command
 listCommand = List <$> (
@@ -170,7 +178,7 @@ parseCommand = (versionOption <*> hsubparser (
   <> command "refresh" (info refreshCommand (progDesc "Re-calculate bookmark indices"))
   <> command "config" (info configCommand (progDesc "View/manage hoyo config"))
   <> command "check" (info checkCommand (progDesc "Verify validity of config and bookmarks"))
-  )) <|> moveCommand
+  )) <|> moveCommandHidden
 
 parseOptions :: Parser Options
 parseOptions = Options <$> parseCommand <*> globalOptions
@@ -182,10 +190,11 @@ versionInfo =
   <> "\n\nCopyright (c) 2022, Frederick Pringle\n\nAll rights reserved."
 
 versionOption :: Parser (a -> a)
-versionOption = infoOption versionInfo (long "version")
+versionOption = infoOption versionInfo (long "version" <> hidden)
 
 options :: ParserInfo Options
 options = info (parseOptions <**> helper) (
           fullDesc
-          <> progDesc "Set directory bookmarks for quick \"cd\"-like behaviour"
+          <> header "Set directory bookmarks for quick \"cd\"-like behaviour"
+          <> progDesc "For more help on a particular sub-command, run `hoyo <cmd> --help`."
           )

--- a/exe/Parse.hs
+++ b/exe/Parse.hs
@@ -161,7 +161,7 @@ checkCommand = Check . noArgs <$> (
                 )
 
 parseCommand :: Parser Command
-parseCommand = versionOption <*> hsubparser (
+parseCommand = (versionOption <*> hsubparser (
   command "add" (info addCommand (progDesc "Add a bookmark"))
   <> command "move" (info moveCommand (progDesc "Change directory using a bookmark"))
   <> command "list" (info listCommand (progDesc "List existing bookmarks"))
@@ -170,7 +170,7 @@ parseCommand = versionOption <*> hsubparser (
   <> command "refresh" (info refreshCommand (progDesc "Re-calculate bookmark indices"))
   <> command "config" (info configCommand (progDesc "View/manage hoyo config"))
   <> command "check" (info checkCommand (progDesc "Verify validity of config and bookmarks"))
-  )
+  )) <|> moveCommand
 
 parseOptions :: Parser Options
 parseOptions = Options <$> parseCommand <*> globalOptions


### PR DESCRIPTION
Make `hoyo move` the default command.

In other words, if there is an existing bookmark with the nickname `docs`, then running `hoyo docs` is the equivalent to running `hoyo move docs`. Likewise if the bookmark index is used.