### PR TITLE
fix a bug in Main.hs

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -18,7 +18,6 @@ failure err = do
 main :: IO ()
 main = withProgName "hoyo" $ do
   opts@(Options _ globals) <- execParser options
-  print opts
   forM_ (verifyOverrides $ overrides globals) failure
 
   sFp <- maybe defaultConfigPath return $ globalConfigPath globals


### PR DESCRIPTION
Fix a bug in Main.hs that would print the Options object before running the appropriate command
